### PR TITLE
Set alpha to 50% for a more immersive experience

### DIFF
--- a/src/activate_linux.c
+++ b/src/activate_linux.c
@@ -50,7 +50,7 @@ static void activate(GtkApplication *app, void *data)
 	int len = 100+title_len+subtitle_len;
 	char text[len];
 
-	snprintf(text, len, "<span font_desc=\"24.0\">%s</span>\n<span font_desc=\"16\">%s</span>", conf->title, conf->subtitle);
+	snprintf(text, len, "<span alpha=\"50%\" font_desc=\"24.0\">%s</span>\n<span alpha=\"50%\" font_desc=\"16\">%s</span>", conf->title, conf->subtitle);
 
 	//GtkWidget *monitor_selection =  monitor_selection_new(gtk_window);
 	GdkDisplay *display = gdk_display_get_default ();


### PR DESCRIPTION
Immersion should be a number one priority for a project like this one. This PR aims at improving the quality of the simulation so that we don't get distracted by details that wouldn't be accurate enough.

Before:
![image](https://user-images.githubusercontent.com/7489759/168620310-b08142bb-fb16-499e-9f98-e56bdfb9f722.png)
After:
![image](https://user-images.githubusercontent.com/7489759/168620256-462027a7-da84-463b-b7d1-197ba19cfa2a.png)
