### PR TITLE
added arguments support

### DIFF
--- a/src/activate_linux.c
+++ b/src/activate_linux.c
@@ -65,8 +65,8 @@ int main(int argc, char **argv)
 	}
 
 	struct config conf;
-	conf.title = "Activate Linux";
-	conf.subtitle = "Go to Settings to activate Linux.";
+	conf.title = argc>1 ? argv[1] : "Activate Linux";
+	conf.subtitle = argc>2 ? argv[2] : "Go to Settings to activate Linux.";
 	GtkApplication *app = gtk_application_new(NULL, G_APPLICATION_FLAGS_NONE);
 	g_signal_connect(app, "activate", G_CALLBACK(activate), (void *) &conf);
 	int status = g_application_run(G_APPLICATION(app), 0, NULL);


### PR DESCRIPTION
Now console arguments are used to display instead of hardcoded text.
Shockingly even non-ascii text working"

![зображення](https://user-images.githubusercontent.com/42848138/169720627-874c71e9-199d-4d5b-901f-0225bf415ad6.png)

![зображення](https://user-images.githubusercontent.com/42848138/169720592-c147cc1c-b914-4a5d-b5f8-b20106666b05.png)